### PR TITLE
Change docker-compose.yml version to 2.0, add logging settings

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3.2"
+version: "2"
 
 services:
   monit:
@@ -6,6 +6,11 @@ services:
     image: monit
     container_name: monit
     hostname: monit
+    logging:
+      driver: json-file
+      options:
+        max-size: "10m"
+        max-file: "5"
     ports:
       - 2812:2812
     volumes:


### PR DESCRIPTION
- `docker-compose.yml` 2.0 and 3.0+ have different compatibility with different Docker versions and it's [preferable](https://stackoverflow.com/a/53636006/961092) to use 2.0 when you don't use swarm;
- without logging settings in `docker-compose.yml` Monit container could clog host machine disk space with log in a long-running scenario, this PR fixes that problem.