### PR TITLE
Fix telegram test command

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Docker documentation: https://docs.docker.com/
 
 - Configure API token and channel id in telegramrc
 
-- Test Telegram with `docker exec monit sendtelegram -c /etc/telegramrc -m "Hello from the other side!"`
+- Test Telegram with `docker-compose run monit sendtelegram -c /etc/telegramrc -m "Hello from the other side\!"`
 
 - Add to checks with `exec` statement
 


### PR DESCRIPTION
Escape exclamation mark, execute the command with docker-compose as
`docker exec` requires not just an image but a container